### PR TITLE
#104 feat: Added ranking by having image

### DIFF
--- a/src/components/SurauList.tsx
+++ b/src/components/SurauList.tsx
@@ -68,7 +68,7 @@ const SurauList = ({
 
   return (
     <div className="bg-white ">
-      <div className="mx-auto max-w-2xl py-2 px-4 shadow-lg sm:py-4 sm:px-6 lg:max-w-7xl lg:px-8">
+      <div className="mx-auto max-w-2xl py-2 px-4 shadow-lg sm:py-4 sm:px-6 lg:max-w-7xl lg:px-8 md:border md:border-gray-100">
         <h2 className="sr-only">Surau</h2>
 
         <div className="grid grid-cols-1 gap-y-10 gap-x-6 p-2 sm:grid-cols-2 md:p-0 lg:grid-cols-4 xl:grid-cols-4 xl:gap-x-6">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -176,12 +176,12 @@ export default function Index() {
           {/* Category section */}
           <section
             aria-labelledby="category-heading"
-            className="pt-4 sm:pt-12 xl:mx-auto xl:max-w-7xl xl:px-8"
+            className="pt-4 sm:pt-12 xl:mx-auto xl:max-w-7xl xl:px-8 md:mb-10"
           >
             <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
               <h2
                 id="category-heading"
-                className="text-2xl font-bold tracking-tight text-gray-900"
+                className="text-2xl font-bold tracking-tight text-gray-900 mb-10"
               >
                 Recently added
               </h2>

--- a/src/server/api/routers/surau.ts
+++ b/src/server/api/routers/surau.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 import { sendApprovalMail } from "../../services/generate-surau-verification";
 import type { Surau } from "../../../../prisma/client";
+import {sortByHavingImage} from "../../../utils/sorter/sortByHavingImage";
 
 export const surauRouter = createTRPCRouter({
   addSurau: publicProcedure
@@ -325,9 +326,11 @@ export const surauRouter = createTRPCRouter({
           name: input.state 
         },
       },
-      // orderBy: {
-      //   created_at: "desc",
-      // },
+      orderBy: {
+        images: {
+          _count: 'desc',
+        },
+      },
       include: {
         state: true,
         district: true,
@@ -349,9 +352,11 @@ export const surauRouter = createTRPCRouter({
             name: input.state 
         },
       },
-      // orderBy: {
-      //   created_at: "desc",
-      // },
+      orderBy: {
+        images: {
+          _count: 'desc',
+        },
+      },
       include: {
         state: true,
         district: true,
@@ -376,7 +381,9 @@ export const surauRouter = createTRPCRouter({
         }, 
       },
       orderBy: {
-        created_at: "desc",
+        images: {
+          _count: 'desc',
+        },
       },
       include: {
         state: true,
@@ -386,7 +393,9 @@ export const surauRouter = createTRPCRouter({
       },
       take: maxtake - surauInDistrict.length - surauInStateButDistrict.length,
     });
-    const suraulocationbased = [...surauInDistrict, ...surauInStateButDistrict, ...allOtherSurau];
+    const suraulocationbased = [
+      ...surauInDistrict, ...surauInStateButDistrict, ...allOtherSurau
+    ].sort(sortByHavingImage);
 
     return suraulocationbased;
   }),

--- a/src/utils/sorter/sortByHavingImage.spec.ts
+++ b/src/utils/sorter/sortByHavingImage.spec.ts
@@ -1,0 +1,14 @@
+import {sortByHavingImage} from "./sortByHavingImage";
+import {surauFactory} from "../../../tests/factory/surau.factory";
+
+describe('utils/sorter/sortByHavingImage', () => {
+  it('can sort by prioritizing records with images', () => {
+    const records = surauFactory
+    expect(records[0]!.images.length).toBe(0)
+
+    const sorted = records.sort(sortByHavingImage)
+
+    expect(sorted[0]!.images.length).toBe(1)
+    expect(sorted[1]!.images.length).toBe(0)
+  })
+})

--- a/src/utils/sorter/sortByHavingImage.ts
+++ b/src/utils/sorter/sortByHavingImage.ts
@@ -1,0 +1,13 @@
+import type {District, Mall, State, Surau, SurauPhoto} from "../../../prisma/client";
+
+export type SurauResponse = (Surau & { state: State, district: District, mall: Mall | null, images: SurauPhoto[] })
+
+export const sortByHavingImage = (leftRecord: SurauResponse, rightRecord: SurauResponse) => {
+  if (leftRecord.images.length === 0 && rightRecord.images.length > 0) {
+    return 1;
+  }
+  if (leftRecord.images.length > 0 && rightRecord.images.length === 0) {
+    return -1;
+  }
+  return 0;
+}

--- a/tests/factory/surau.factory.ts
+++ b/tests/factory/surau.factory.ts
@@ -1,0 +1,67 @@
+import type {SurauResponse} from "../../src/utils/sorter/sortByHavingImage";
+
+export const surauFactory: SurauResponse[] = [
+  {
+    id: 'cllzkztw4000ctaxo65ephba1',
+    name: 'Surau without image 1',
+    unique_name: 'surau-without-image-1-zte',
+    brief_direction: 'Test 3',
+    is_approved: true,
+    is_approved_at: null,
+    created_at: new Date('2023-08-31T19:50:55.253Z'),
+    updated_at: new Date('2023-08-31T19:50:55.253Z'),
+    state_id: 'clildu63s001ii0h0f8i8jehj',
+    district_id: 'clildu651001ki0h0q59yg2s1',
+    mall_id: null,
+    is_qiblat_certified: false,
+    state: {
+      id: 'clildu63s001ii0h0f8i8jehj',
+      name: 'Melaka',
+      unique_name: 'melaka'
+    },
+    district: {
+      id: 'clildu651001ki0h0q59yg2s1',
+      name: 'Alor Gajah',
+      unique_name: 'alor-gajah',
+      state_id: 'clildu63s001ii0h0f8i8jehj'
+    },
+    mall: null,
+    images: []
+  },
+  {
+    id: 'cllzkxhil0008taxo43hiqtpx',
+    name: 'Example 2',
+    unique_name: 'example-2-xfg',
+    brief_direction: 'Test Local',
+    is_approved: true,
+    is_approved_at: null,
+    created_at: new Date('2023-08-31T19:49:05.902Z'),
+    updated_at: new Date('2023-08-31T19:49:05.902Z'),
+    state_id: 'clildu63s001ii0h0f8i8jehj',
+    district_id: 'clildu651001ki0h0q59yg2s1',
+    mall_id: null,
+    is_qiblat_certified: false,
+    state: {
+      id: 'clildu63s001ii0h0f8i8jehj',
+      name: 'Melaka',
+      unique_name: 'melaka'
+    },
+    district: {
+      id: 'clildu651001ki0h0q59yg2s1',
+      name: 'Alor Gajah',
+      unique_name: 'alor-gajah',
+      state_id: 'clildu63s001ii0h0f8i8jehj'
+    },
+    mall: null,
+    images: [
+      {
+        id: 'cllpfpdsk001ymo08c1whjhv6',
+        file_path: 'https://images.unsplash.com/photo-1682695797221-8164ff1fafc9?ixlib=rb-4.0.3&ixid=M3wxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2670&q=80',
+        caption: null,
+        created_at: new Date('2023-08-31T19:52:53.485Z'),
+        surau_id: 'cllzkxhil0008taxo43hiqtpx',
+        rating_id: null
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Overview

Allow ranking by surau with images first for visual attraction.

## Overlook

### 1 - With image ranking 🎉
Here's one with image ranking:

<img width="400" alt="image" src="https://github.com/farhan-helmy/ratemysurau/assets/14009259/f06f221d-a775-4351-9c27-0b59b18c0456">

### 2 - Without image ranking 😢

<img width="400" alt="image" src="https://github.com/farhan-helmy/ratemysurau/assets/14009259/cde6b395-7594-45fe-8c32-5bf93c712ab9">


## Further info

Can be seen from the unit-test.

Added tiny bit of CSS to fix the view on md+ (tablet and above) screens. See comment:

https://github.com/farhan-helmy/ratemysurau/pull/106/files#r1312220940

Closes #104 